### PR TITLE
サーバ側 - ログの導入②（最新ブランチに対して）_ログローテ現状

### DIFF
--- a/server/cmd/intime/main.go
+++ b/server/cmd/intime/main.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/gin-gonic/gin"
 	"intimeServer/api/handler"
+
+	"github.com/gin-gonic/gin"
 )
 
 // @title gin-swagger todos

--- a/server/config/config_staging.go
+++ b/server/config/config_staging.go
@@ -2,3 +2,8 @@ package config
 
 // 設定のやつ
 // https://eltonminetto.dev/post/2018-06-25-golang-usando-build-tags/
+
+const (
+	// TODO : ログ出力先を決める
+	LOG_FILE_NAME = "./test.log"
+)

--- a/server/config/config_staging.go
+++ b/server/config/config_staging.go
@@ -4,6 +4,5 @@ package config
 // https://eltonminetto.dev/post/2018-06-25-golang-usando-build-tags/
 
 const (
-	// TODO : ログ出力先を決める
-	LOG_FILE_NAME = "./test.log"
+	LOG_FILE_NAME = "/var/log/go/application.log"
 )

--- a/server/go.mod
+++ b/server/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-playground/validator/v10 v10.11.1 // indirect
+	github.com/goark/errs v1.3.2 // indirect
 	github.com/goccy/go-json v0.10.0 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/uuid v1.3.0 // indirect
@@ -32,11 +33,13 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
+	github.com/rs/zerolog v1.29.1 // indirect
 	github.com/swaggo/files v0.0.0-20220728132757-551d4a08d97a // indirect
 	github.com/swaggo/gin-swagger v1.5.3 // indirect
 	github.com/swaggo/swag v1.8.8 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -16,6 +16,7 @@ github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agiledragon/gomonkey/v2 v2.3.1/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
+github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -55,10 +56,13 @@ github.com/go-playground/validator/v10 v10.11.1/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
+github.com/goark/errs v1.3.2 h1:ifccNe1aK7Xezt4XVYwHUqalmnfhuphnEvh3FshCReQ=
+github.com/goark/errs v1.3.2/go.mod h1:ZsQucxaDFVfSB8I99j4bxkDRfNOrlKINwg72QMuRWKw=
 github.com/goccy/go-json v0.9.7 h1:IcB+Aqpx/iMHu5Yooh7jEzJk1JZ7Pjtmys2ukPr7EeM=
 github.com/goccy/go-json v0.9.7/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-json v0.10.0 h1:mXKd9Qw4NuzShiRlOXKews24ufknHO7gx30lsDyokKA=
 github.com/goccy/go-json v0.10.0/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
@@ -93,6 +97,8 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
+github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
@@ -118,11 +124,15 @@ github.com/pelletier/go-toml/v2 v2.0.1/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZO
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
+github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rs/zerolog v1.29.1 h1:cO+d60CHkknCbvzEWxP0S9K6KqyTjrCNUy1LdQLCGPc=
+github.com/rs/zerolog v1.29.1/go.mod h1:Le6ESbR7hc+DP6Lt1THiV8CQSdkkNrd3R0XbEgp3ZBU=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -196,6 +206,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/server/pkg/zlog/zlog.go
+++ b/server/pkg/zlog/zlog.go
@@ -1,0 +1,150 @@
+package zlog
+
+import (
+	config "intimeServer/config"
+	"io"
+	"os"
+
+	"github.com/goark/errs"
+	"github.com/rs/zerolog"
+)
+
+func Trace(msg string) {
+	// ファイル出力先指定
+	zlog := zerolog.Nop()
+	file, err := os.OpenFile(config.LOG_FILE_NAME, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		zlog = zerolog.New(os.Stdout)
+	} else {
+		zlog = zerolog.New(io.MultiWriter(
+			file,
+			zerolog.ConsoleWriter{Out: os.Stdout, NoColor: false},
+		))
+	}
+	// タイムスタンプ設定
+	zlog = zlog.Level(zerolog.DebugLevel).With().Timestamp().Caller().Logger()
+	if err != nil {
+		zlog.Error().Interface("error", errs.Wrap(err, errs.WithContext("file", file))).Str("file", config.LOG_FILE_NAME).Msg("error in opening logfile")
+	}
+	zlog.Trace().Msg(msg)
+}
+
+func Debug(msg string) {
+	// ファイル出力先指定
+	zlog := zerolog.Nop()
+	file, err := os.OpenFile(config.LOG_FILE_NAME, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		zlog = zerolog.New(os.Stdout)
+	} else {
+		zlog = zerolog.New(io.MultiWriter(
+			file,
+			zerolog.ConsoleWriter{Out: os.Stdout, NoColor: false},
+		))
+	}
+	// タイムスタンプ設定
+	zlog = zlog.Level(zerolog.DebugLevel).With().Timestamp().Caller().Logger()
+	if err != nil {
+		zlog.Error().Interface("error", errs.Wrap(err, errs.WithContext("file", file))).Str("file", config.LOG_FILE_NAME).Msg("error in opening logfile")
+	}
+	zlog.Debug().Msg(msg)
+}
+
+func Info(msg string) {
+	// ファイル出力先指定
+	zlog := zerolog.Nop()
+	file, err := os.OpenFile(config.LOG_FILE_NAME, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		zlog = zerolog.New(os.Stdout)
+	} else {
+		zlog = zerolog.New(io.MultiWriter(
+			file,
+			zerolog.ConsoleWriter{Out: os.Stdout, NoColor: false},
+		))
+	}
+	// タイムスタンプ設定
+	zlog = zlog.Level(zerolog.DebugLevel).With().Timestamp().Caller().Logger()
+	if err != nil {
+		zlog.Error().Interface("error", errs.Wrap(err, errs.WithContext("file", file))).Str("file", config.LOG_FILE_NAME).Msg("error in opening logfile")
+	}
+	zlog.Info().Msg(msg)
+}
+
+func Warn(msg string) {
+	// ファイル出力先指定
+	zlog := zerolog.Nop()
+	file, err := os.OpenFile(config.LOG_FILE_NAME, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		zlog = zerolog.New(os.Stdout)
+	} else {
+		zlog = zerolog.New(io.MultiWriter(
+			file,
+			zerolog.ConsoleWriter{Out: os.Stdout, NoColor: false},
+		))
+	}
+	// タイムスタンプ設定
+	zlog = zlog.Level(zerolog.DebugLevel).With().Timestamp().Caller().Logger()
+	if err != nil {
+		zlog.Error().Interface("error", errs.Wrap(err, errs.WithContext("file", file))).Str("file", config.LOG_FILE_NAME).Msg("error in opening logfile")
+	}
+	zlog.Warn().Msg(msg)
+}
+
+func Error(msg string) {
+	// ファイル出力先指定
+	zlog := zerolog.Nop()
+	file, err := os.OpenFile(config.LOG_FILE_NAME, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		zlog = zerolog.New(os.Stdout)
+	} else {
+		zlog = zerolog.New(io.MultiWriter(
+			file,
+			zerolog.ConsoleWriter{Out: os.Stdout, NoColor: false},
+		))
+	}
+	// タイムスタンプ設定
+	zlog = zlog.Level(zerolog.DebugLevel).With().Timestamp().Caller().Logger()
+	if err != nil {
+		zlog.Error().Interface("error", errs.Wrap(err, errs.WithContext("file", file))).Str("file", config.LOG_FILE_NAME).Msg("error in opening logfile")
+	}
+	zlog.Error().Stack().Err(err).Msg(msg)
+}
+
+func Fatal(msg string) {
+	// ファイル出力先指定
+	zlog := zerolog.Nop()
+	file, err := os.OpenFile(config.LOG_FILE_NAME, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		zlog = zerolog.New(os.Stdout)
+	} else {
+		zlog = zerolog.New(io.MultiWriter(
+			file,
+			zerolog.ConsoleWriter{Out: os.Stdout, NoColor: false},
+		))
+	}
+	// タイムスタンプ設定
+	zlog = zlog.Level(zerolog.DebugLevel).With().Timestamp().Caller().Logger()
+	if err != nil {
+		zlog.Error().Interface("error", errs.Wrap(err, errs.WithContext("file", file))).Str("file", config.LOG_FILE_NAME).Msg("error in opening logfile")
+	}
+	zlog.Fatal().Msg(msg)
+}
+
+func Panic(msg string) {
+	// ファイル出力先指定
+	zlog := zerolog.Nop()
+	file, err := os.OpenFile(config.LOG_FILE_NAME, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		zlog = zerolog.New(os.Stdout)
+	} else {
+		zlog = zerolog.New(io.MultiWriter(
+			file,
+			zerolog.ConsoleWriter{Out: os.Stdout, NoColor: false},
+		))
+	}
+	// タイムスタンプ設定
+	zlog = zlog.Level(zerolog.DebugLevel).With().Timestamp().Caller().Logger()
+	if err != nil {
+		zlog.Error().Interface("error", errs.Wrap(err, errs.WithContext("file", file))).Str("file", config.LOG_FILE_NAME).Msg("error in opening logfile")
+	}
+	zlog.Panic().Msg(msg)
+}

--- a/server/pkg/zlog/zlog.go
+++ b/server/pkg/zlog/zlog.go
@@ -1,150 +1,112 @@
 package zlog
 
 import (
-	config "intimeServer/config"
+	"fmt"
+	"intimeServer/config"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/goark/errs"
 	"github.com/rs/zerolog"
 )
 
+var logger *zerolog.Logger
+var once sync.Once
+
 func Trace(msg string) {
-	// ファイル出力先指定
-	zlog := zerolog.Nop()
-	file, err := os.OpenFile(config.LOG_FILE_NAME, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-	if err != nil {
-		zlog = zerolog.New(os.Stdout)
-	} else {
-		zlog = zerolog.New(io.MultiWriter(
-			file,
-			zerolog.ConsoleWriter{Out: os.Stdout, NoColor: false},
-		))
-	}
-	// タイムスタンプ設定
-	zlog = zlog.Level(zerolog.DebugLevel).With().Timestamp().Caller().Logger()
-	if err != nil {
-		zlog.Error().Interface("error", errs.Wrap(err, errs.WithContext("file", file))).Str("file", config.LOG_FILE_NAME).Msg("error in opening logfile")
-	}
+	zlog := setupLogger()
 	zlog.Trace().Msg(msg)
 }
 
 func Debug(msg string) {
-	// ファイル出力先指定
-	zlog := zerolog.Nop()
-	file, err := os.OpenFile(config.LOG_FILE_NAME, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-	if err != nil {
-		zlog = zerolog.New(os.Stdout)
-	} else {
-		zlog = zerolog.New(io.MultiWriter(
-			file,
-			zerolog.ConsoleWriter{Out: os.Stdout, NoColor: false},
-		))
-	}
-	// タイムスタンプ設定
-	zlog = zlog.Level(zerolog.DebugLevel).With().Timestamp().Caller().Logger()
-	if err != nil {
-		zlog.Error().Interface("error", errs.Wrap(err, errs.WithContext("file", file))).Str("file", config.LOG_FILE_NAME).Msg("error in opening logfile")
-	}
+	zlog := setupLogger()
 	zlog.Debug().Msg(msg)
 }
 
 func Info(msg string) {
-	// ファイル出力先指定
-	zlog := zerolog.Nop()
-	file, err := os.OpenFile(config.LOG_FILE_NAME, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-	if err != nil {
-		zlog = zerolog.New(os.Stdout)
-	} else {
-		zlog = zerolog.New(io.MultiWriter(
-			file,
-			zerolog.ConsoleWriter{Out: os.Stdout, NoColor: false},
-		))
-	}
-	// タイムスタンプ設定
-	zlog = zlog.Level(zerolog.DebugLevel).With().Timestamp().Caller().Logger()
-	if err != nil {
-		zlog.Error().Interface("error", errs.Wrap(err, errs.WithContext("file", file))).Str("file", config.LOG_FILE_NAME).Msg("error in opening logfile")
-	}
+	zlog := setupLogger()
 	zlog.Info().Msg(msg)
 }
 
 func Warn(msg string) {
-	// ファイル出力先指定
-	zlog := zerolog.Nop()
-	file, err := os.OpenFile(config.LOG_FILE_NAME, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-	if err != nil {
-		zlog = zerolog.New(os.Stdout)
-	} else {
-		zlog = zerolog.New(io.MultiWriter(
-			file,
-			zerolog.ConsoleWriter{Out: os.Stdout, NoColor: false},
-		))
-	}
-	// タイムスタンプ設定
-	zlog = zlog.Level(zerolog.DebugLevel).With().Timestamp().Caller().Logger()
-	if err != nil {
-		zlog.Error().Interface("error", errs.Wrap(err, errs.WithContext("file", file))).Str("file", config.LOG_FILE_NAME).Msg("error in opening logfile")
-	}
+	zlog := setupLogger()
 	zlog.Warn().Msg(msg)
 }
 
 func Error(msg string) {
-	// ファイル出力先指定
-	zlog := zerolog.Nop()
-	file, err := os.OpenFile(config.LOG_FILE_NAME, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-	if err != nil {
-		zlog = zerolog.New(os.Stdout)
-	} else {
-		zlog = zerolog.New(io.MultiWriter(
-			file,
-			zerolog.ConsoleWriter{Out: os.Stdout, NoColor: false},
-		))
-	}
-	// タイムスタンプ設定
-	zlog = zlog.Level(zerolog.DebugLevel).With().Timestamp().Caller().Logger()
-	if err != nil {
-		zlog.Error().Interface("error", errs.Wrap(err, errs.WithContext("file", file))).Str("file", config.LOG_FILE_NAME).Msg("error in opening logfile")
-	}
-	zlog.Error().Stack().Err(err).Msg(msg)
+	zlog := setupLogger()
+	zlog.Error().Msg(msg)
 }
 
 func Fatal(msg string) {
-	// ファイル出力先指定
-	zlog := zerolog.Nop()
-	file, err := os.OpenFile(config.LOG_FILE_NAME, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-	if err != nil {
-		zlog = zerolog.New(os.Stdout)
-	} else {
-		zlog = zerolog.New(io.MultiWriter(
-			file,
-			zerolog.ConsoleWriter{Out: os.Stdout, NoColor: false},
-		))
-	}
-	// タイムスタンプ設定
-	zlog = zlog.Level(zerolog.DebugLevel).With().Timestamp().Caller().Logger()
-	if err != nil {
-		zlog.Error().Interface("error", errs.Wrap(err, errs.WithContext("file", file))).Str("file", config.LOG_FILE_NAME).Msg("error in opening logfile")
-	}
+	zlog := setupLogger()
 	zlog.Fatal().Msg(msg)
 }
 
 func Panic(msg string) {
-	// ファイル出力先指定
-	zlog := zerolog.Nop()
-	file, err := os.OpenFile(config.LOG_FILE_NAME, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-	if err != nil {
-		zlog = zerolog.New(os.Stdout)
-	} else {
-		zlog = zerolog.New(io.MultiWriter(
-			file,
-			zerolog.ConsoleWriter{Out: os.Stdout, NoColor: false},
-		))
-	}
-	// タイムスタンプ設定
-	zlog = zlog.Level(zerolog.DebugLevel).With().Timestamp().Caller().Logger()
-	if err != nil {
-		zlog.Error().Interface("error", errs.Wrap(err, errs.WithContext("file", file))).Str("file", config.LOG_FILE_NAME).Msg("error in opening logfile")
-	}
+	zlog := setupLogger()
 	zlog.Panic().Msg(msg)
+}
+
+func setupLogger() *zerolog.Logger {
+	// 今日の日付を取得
+	today := time.Now().Format("2006-01-02")
+	// ファイル名に今日の日付を追加
+	fileName := config.LOG_FILE_NAME + "_" + today
+	// ファイルが存在するかどうかを確認
+	_, err := os.Stat(fileName)
+
+	// ファイル名に含まれる日付と現在の日付が同じか確認
+	if os.IsNotExist(err) || !isSameDay(fileName) {
+		// 一度だけ実行する
+		once.Do(func() {
+			fmt.Println("setupLogger 関数が一度だけ実行されました")
+
+			dir := filepath.Dir(fileName)
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				zlog := zerolog.New(os.Stdout)
+				zlog.Error().Interface("error", errs.Wrap(err, errs.WithContext("dir", dir))).Msg("ログディレクトリの作成エラー")
+			}
+
+			file, err := os.Create(fileName)
+			if err != nil {
+				zlog := zerolog.New(os.Stdout)
+				zlog.Error().Interface("error", errs.Wrap(err, errs.WithContext("file", fileName))).Msg("ログファイルの作成エラー")
+			} else {
+				file.Close()
+			}
+
+			openFile, openErr := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+			if openErr != nil {
+				zlog := zerolog.New(os.Stdout)
+				zlog.Error().Interface("error", errs.Wrap(err, errs.WithContext("file", fileName))).Msg("ログファイルのオープンエラー")
+			}
+
+			// タイムスタンプ設定
+			zlog := zerolog.New(io.MultiWriter(
+				openFile,
+				zerolog.ConsoleWriter{Out: os.Stdout, NoColor: false},
+			)).Level(zerolog.DebugLevel).With().Timestamp().Caller().Logger()
+
+			// 設定された状態のzerolog.Loggerを返却
+			logger = &zlog
+		})
+	}
+
+	return logger
+}
+
+// ファイル名に含まれる日付と現在の日付が同じ日かどうかを判定
+func isSameDay(fileName string) bool {
+	// ファイル名から日付を抽出
+	parts := strings.Split(fileName, "_")
+	if len(parts) != 2 {
+		return false
+	}
+	// ファイル名の日付と現在の日付を比較
+	return parts[1] == time.Now().Format("2006-01-02")
 }

--- a/server/usecase/book/service.go
+++ b/server/usecase/book/service.go
@@ -3,9 +3,11 @@ package book
 import (
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	_ "intimeServer/docs"
 	"intimeServer/internal/model"
+	"intimeServer/pkg/zlog"
+
+	"github.com/gin-gonic/gin"
 )
 
 // インターフェースアダプタ層
@@ -24,6 +26,7 @@ var books = []model.Book{
 @Router /books [get]
 */
 func GetBook(c *gin.Context) {
+	zlog.Error("aaaaa")
 	c.JSON(200, books)
 }
 


### PR DESCRIPTION
ログローテに関して、アプリ起動時に1度だけファイルを開く処理が可能そうだったため一度試しで動かしてみました！
現実装ですと以下の場合にファイル作成して開くような感じになってます。
・ファイルが存在しない場合
・ファイル名の日付と現日付が違う場合

今見つかっているバグとして、
・アプリ起動後、ファイルがなくなった場合にエラー
・1度ファイルが作られた状態でアプリが再起動した際にエラー
です。。。ロジックの問題だと思うので調査しながら修正します！
