### PR TITLE
コンテナで開いた際に設定ファイルがコンテナ内に配置されるように構成を変更

### DIFF
--- a/client/.devcontainer/devcontainer.json
+++ b/client/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 		"../../docker-compose.yml"
 	],
 	"service": "client",
-	"workspaceFolder": "/usr/src/app", // 起動時に開くフォルダを指定
+	"workspaceFolder": "/usr/src", // 起動時に開くフォルダを指定
 	"shutdownAction": "stopCompose",
 	// Sets the run context to one level up instead of the .devcontainer folder.
 	//"context": "..",

--- a/client/.vscode/settings.json
+++ b/client/.vscode/settings.json
@@ -2,8 +2,8 @@
     "emeraldwalk.runonsave": {
         "commands": [
             {
-                "match": "*.tsx",
-                "cmd": "yarn install"
+                "match": "\\.tsx$",
+                "cmd": "cd ./app && yarn install"
             }
         ]
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,6 @@ services:
     environment:
       TZ: Asia/Tokyo
     volumes:
-      - ./client/app:/usr/src/app
+      - ./client:/usr/src
     working_dir: /usr/src/app
     command: /bin/sh -c "yarn install && yarn start" # reactの起動なども行っている。


### PR DESCRIPTION
- `.vscode` ディレクトリがコンテナ内に配置されておらず、コンテナ上での開発時に設定ファイルを認識しないため認識するように修正
- 上記修正に伴い、`yarn install` 実行前に `app` ディレクトリに移動するように追記
- tsx ファイルの保存時にトリガー認識されず実行されていなかったため `match` の条件を修正

これら変更に伴い、vscode を利用して開発コンテナを開いた際はターミナルの初期ディレクトリが `/usr/src` 配下になるため直接 yarn コマンドを実行する際は app 配下に移動すること。